### PR TITLE
Implement notification endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,8 @@ Todas as rotas (exceto login e registro) requerem um token JWT no header `Author
 - `DELETE /api/posts/:id` - Deletar post
 - `GET /api/posts/user/:userId` - Buscar posts por usuário
 - `GET /api/posts/pet/:petId` - Buscar posts por pet
+
+### Notificações
+
+- `POST /api/notifications/register` - Registrar token de push do dispositivo
+- `POST /api/notifications/nearby` - Enviar notificações para usuários próximos

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "morgan": "^1.10.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "node-fetch": "^3.3.2",
     "zod": "^3.25.46"
   },
   "devDependencies": {

--- a/prisma/migrations/20250605120000_add_notification_tokens/migration.sql
+++ b/prisma/migrations/20250605120000_add_notification_tokens/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "NotificationToken" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "NotificationToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationToken_token_key" ON "NotificationToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "NotificationToken" ADD CONSTRAINT "NotificationToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   updatedAt DateTime @updatedAt
   pets      Pet[]
   posts     Post[]
+  tokens    NotificationToken[]
 }
 
 enum PetGender {
@@ -82,4 +83,13 @@ model Post {
   status    PostStatus
   createdAt DateTime   @default(now())
   updatedAt DateTime   @updatedAt
+}
+
+model NotificationToken {
+  id        String   @id @default(uuid())
+  token     String   @unique
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }

--- a/src/controllers/NotificationController.ts
+++ b/src/controllers/NotificationController.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { NotificationService } from '../services/NotificationService';
+
+export class NotificationController {
+  private service: NotificationService;
+
+  constructor() {
+    this.service = new NotificationService();
+  }
+
+  register = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { token } = req.body as { token: string };
+      await this.service.registerToken(token, req.user.id);
+      res.status(StatusCodes.NO_CONTENT).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  notifyNearby = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { postId } = req.body as { postId: string };
+      await this.service.notifyNearbyUsers(postId);
+      res.status(StatusCodes.NO_CONTENT).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/repositories/NotificationTokenRepository.ts
+++ b/src/repositories/NotificationTokenRepository.ts
@@ -1,0 +1,32 @@
+import { PrismaClient, NotificationToken } from '@prisma/client';
+
+export class NotificationTokenRepository {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  async upsert(token: string, userId: string): Promise<NotificationToken> {
+    const existing = await this.prisma.notificationToken.findUnique({
+      where: { token }
+    });
+
+    if (existing) {
+      return this.prisma.notificationToken.update({
+        where: { token },
+        data: { userId }
+      });
+    }
+
+    return this.prisma.notificationToken.create({
+      data: { token, userId }
+    });
+  }
+
+  async findByUserIds(userIds: string[]): Promise<NotificationToken[]> {
+    return this.prisma.notificationToken.findMany({
+      where: { userId: { in: userIds } }
+    });
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import authRoutes from './auth.routes';
 import petRoutes from './pet.routes';
 import postRoutes from './post.routes';
 import userRoutes from './user.routes';
+import notificationRoutes from './notification.routes';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use('/auth', authRoutes);
 router.use('/users', authMiddleware as RequestHandler, userRoutes);
 router.use('/pets', authMiddleware as RequestHandler, petRoutes);
 router.use('/posts', authMiddleware as RequestHandler, postRoutes);
+router.use('/notifications', authMiddleware as RequestHandler, notificationRoutes);
 
 export default router; 

--- a/src/routes/notification.routes.ts
+++ b/src/routes/notification.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { NotificationController } from '../controllers/NotificationController';
+import { authMiddleware } from '../middlewares/auth';
+import { validate } from '../middlewares/validate';
+import { registerTokenSchema, notifyNearbySchema } from '../schemas/notification.schema';
+
+const router = Router();
+const controller = new NotificationController();
+
+router.post('/register', authMiddleware, validate(registerTokenSchema), controller.register);
+router.post('/nearby', authMiddleware, validate(notifyNearbySchema), controller.notifyNearby);
+
+export default router;

--- a/src/schemas/notification.schema.ts
+++ b/src/schemas/notification.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const registerTokenSchema = z.object({
+  body: z.object({
+    token: z.string().min(10)
+  })
+});
+
+export const notifyNearbySchema = z.object({
+  body: z.object({
+    postId: z.string().uuid()
+  })
+});
+
+export type RegisterTokenInput = z.infer<typeof registerTokenSchema>['body'];
+export type NotifyNearbyInput = z.infer<typeof notifyNearbySchema>['body'];

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,0 +1,75 @@
+import { PrismaClient } from '@prisma/client';
+import fetch from 'node-fetch';
+import { NotificationTokenRepository } from '../repositories/NotificationTokenRepository';
+
+export class NotificationService {
+  private prisma: PrismaClient;
+  private tokenRepo: NotificationTokenRepository;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+    this.tokenRepo = new NotificationTokenRepository();
+  }
+
+  async registerToken(token: string, userId: string) {
+    await this.tokenRepo.upsert(token, userId);
+  }
+
+  private getDistanceKm(lat1: number, lon1: number, lat2: number, lon2: number) {
+    const R = 6371; // km
+    const dLat = (lat2 - lat1) * (Math.PI / 180);
+    const dLon = (lon2 - lon1) * (Math.PI / 180);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(lat1 * (Math.PI / 180)) *
+        Math.cos(lat2 * (Math.PI / 180)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+  }
+
+  async notifyNearbyUsers(postId: string) {
+    const post = await this.prisma.post.findUnique({
+      where: { id: postId },
+      include: {
+        user: true
+      }
+    });
+
+    if (!post || post.user.latitude == null || post.user.longitude == null) {
+      return;
+    }
+
+    const users = await this.prisma.user.findMany({
+      where: {
+        id: { not: post.userId },
+        latitude: { not: null },
+        longitude: { not: null }
+      }
+    });
+
+    const nearbyUserIds = users
+      .filter(u =>
+        this.getDistanceKm(
+          post.user.latitude!,
+          post.user.longitude!,
+          u.latitude!,
+          u.longitude!
+        ) <= 10
+      )
+      .map(u => u.id);
+
+    if (!nearbyUserIds.length) return;
+
+    const tokens = await this.tokenRepo.findByUserIds(nearbyUserIds);
+
+    const messages = tokens.map(t => ({ to: t.token, sound: 'default', body: 'Há um novo post perto de você!' }));
+
+    await fetch('https://exp.host/--/api/v2/push/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(messages)
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- support Expo push tokens with NotificationToken table
- register and notify push tokens via new service
- expose POST /api/notifications routes
- document notification routes in README

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e180290832dad17d1a17e16061b