### PR TITLE
Add image upload with Supabase storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ JWT_SECRET=seu_jwt_secret_aqui
 # Supabase
 DATABASE_URL="postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT-REF].supabase.co:5432/postgres"
 DIRECT_URL="postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT-REF].supabase.co:5432/postgres"
+
+# Supabase Storage
+SUPABASE_URL=https://[YOUR-PROJECT-REF].supabase.co
+SUPABASE_ANON_KEY=[YOUR-ANON-KEY]
+SUPABASE_BUCKET=images

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Edite o arquivo `.env` com suas configurações do Supabase:
 - `DATABASE_URL`: URL de conexão do seu banco de dados Supabase
 - `JWT_SECRET`: Chave secreta para geração dos tokens JWT
 - `PORT`: Porta onde a API irá rodar (opcional, padrão: 3000)
+- `SUPABASE_URL`: URL do projeto Supabase
+- `SUPABASE_ANON_KEY`: Chave pública do Supabase
+- `SUPABASE_BUCKET`: Bucket de armazenamento para as imagens (opcional)
 
 4. Execute as migrações do banco de dados:
 ```bash
@@ -82,3 +85,7 @@ Todas as rotas (exceto login e registro) requerem um token JWT no header `Author
 - `DELETE /api/posts/:id` - Deletar post
 - `GET /api/posts/user/:userId` - Buscar posts por usuário
 - `GET /api/posts/pet/:petId` - Buscar posts por pet
+
+### Uploads
+
+- `POST /api/uploads` - Enviar uma imagem (campo `file` no form-data)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "morgan": "^1.10.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
-    "zod": "^3.25.46"
+    "zod": "^3.25.46",
+    "@supabase/supabase-js": "^2.39.5",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -45,6 +47,7 @@
     "prisma": "^6.8.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/multer": "^1.4.7"
   }
 }

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabaseUrl = process.env.SUPABASE_URL || '';
+const supabaseKey = process.env.SUPABASE_ANON_KEY || '';
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/controllers/UploadController.ts
+++ b/src/controllers/UploadController.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { UploadService } from '../services/UploadService';
+
+export class UploadController {
+  private uploadService: UploadService;
+
+  constructor() {
+    this.uploadService = new UploadService();
+  }
+
+  upload = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (!req.file) {
+        return res.status(StatusCodes.BAD_REQUEST).json({ error: 'Arquivo não enviado' });
+      }
+
+      const url = await this.uploadService.uploadImage(req.file);
+      res.status(StatusCodes.CREATED).json({ url });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import authRoutes from './auth.routes';
 import petRoutes from './pet.routes';
 import postRoutes from './post.routes';
 import userRoutes from './user.routes';
+import uploadRoutes from './upload.routes';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use('/auth', authRoutes);
 router.use('/users', authMiddleware as RequestHandler, userRoutes);
 router.use('/pets', authMiddleware as RequestHandler, petRoutes);
 router.use('/posts', authMiddleware as RequestHandler, postRoutes);
+router.use('/uploads', authMiddleware as RequestHandler, uploadRoutes);
 
 export default router; 

--- a/src/routes/upload.routes.ts
+++ b/src/routes/upload.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { UploadController } from '../controllers/UploadController';
+import { authMiddleware } from '../middlewares/auth';
+
+const router = Router();
+const uploadController = new UploadController();
+const upload = multer();
+
+router.post('/', authMiddleware, upload.single('file'), uploadController.upload);
+
+export default router;

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -1,0 +1,25 @@
+import { StatusCodes } from 'http-status-codes';
+import { supabase } from '../config/supabase';
+import { AppError } from '../errors/AppError';
+
+export class UploadService {
+  private bucket: string;
+
+  constructor() {
+    this.bucket = process.env.SUPABASE_BUCKET || 'images';
+  }
+
+  async uploadImage(file: Express.Multer.File): Promise<string> {
+    const filePath = `${Date.now()}-${file.originalname}`;
+    const { error } = await supabase.storage.from(this.bucket).upload(filePath, file.buffer, {
+      contentType: file.mimetype
+    });
+
+    if (error) {
+      throw new AppError('Erro ao fazer upload da imagem', StatusCodes.INTERNAL_SERVER_ERROR);
+    }
+
+    const { data } = supabase.storage.from(this.bucket).getPublicUrl(filePath);
+    return data.publicUrl;
+  }
+}


### PR DESCRIPTION
## Summary
- allow configuration for Supabase storage
- support image uploads via new service and controller
- expose `/api/uploads` route
- document new environment variables and API route

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fa4e868f8832da897e5962bb1de17