### PR TITLE
Use singleton Prisma client

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,6 @@
 import { PetGender, PetSize, PostStatus, PostType, PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
-
-const prisma = new PrismaClient();
+import { prisma } from '../src/config/prisma';
 
 async function main() {
   // Limpar o banco de dados

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -1,0 +1,4 @@
+import { PrismaClient } from '@prisma/client';
+
+// Export a single PrismaClient instance to be shared across the app
+export const prisma = new PrismaClient();

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -3,8 +3,8 @@ import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import * as jwt from 'jsonwebtoken';
 import { UserResponse } from '../types';
+import { prisma } from '../config/prisma';
 
-const prisma = new PrismaClient();
 
 interface TokenPayload {
   id: string;

--- a/src/repositories/PetRepository.ts
+++ b/src/repositories/PetRepository.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { prisma } from '../config/prisma';
 import { PetCreate, PetResponse } from '../types';
 import { IRepository } from './interfaces/IRepository';
 
@@ -6,7 +7,7 @@ export class PetRepository implements IRepository<PetResponse> {
   private prisma: PrismaClient;
 
   constructor() {
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   async findAll(): Promise<PetResponse[]> {

--- a/src/repositories/PostRepository.ts
+++ b/src/repositories/PostRepository.ts
@@ -1,12 +1,13 @@
 import { Post, PrismaClient } from '@prisma/client';
 import { CreatePostDTO, PostFilters, UpdatePostDTO } from '../types';
 import { IRepository } from './interfaces/IRepository';
+import { prisma } from '../config/prisma';
 
 export class PostRepository implements IRepository<Post> {
   private prisma: PrismaClient;
 
   constructor() {
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   async findAll(): Promise<Post[]> {

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -1,12 +1,13 @@
 import { PrismaClient, User } from '@prisma/client';
 import { CreateUserDTO, UpdateUserDTO } from '../types';
 import { IRepository } from './interfaces/IRepository';
+import { prisma } from '../config/prisma';
 
 export class UserRepository implements IRepository<User> {
   private prisma: PrismaClient;
 
   constructor() {
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   async create(data: CreateUserDTO): Promise<User> {

--- a/src/services/PetService.ts
+++ b/src/services/PetService.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { prisma } from '../config/prisma';
 import { StatusCodes } from 'http-status-codes';
 import { AppError } from '../errors/AppError';
 import { PetRepository } from '../repositories/PetRepository';
@@ -10,7 +11,7 @@ export class PetService {
 
   constructor() {
     this.repository = new PetRepository();
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   async findAll(): Promise<PetResponse[]> {

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { AppError } from '../errors/AppError';
 import { PostRepository } from '../repositories/PostRepository';
 import { CreatePostDTO, PostFilters, UpdatePostDTO } from '../types';
+import { prisma } from '../config/prisma';
 
 export class PostService {
   private repository: PostRepository;
@@ -10,7 +11,7 @@ export class PostService {
 
   constructor() {
     this.repository = new PostRepository();
-    this.prisma = new PrismaClient();
+    this.prisma = prisma;
   }
 
   async findAll(): Promise<Post[]> {


### PR DESCRIPTION
## Summary
- add a shared Prisma client in `src/config/prisma.ts`
- use the shared client in repositories, services, middleware and seed script

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_683fab92b3a4832d82f9ddc37186a5c2