### PR TITLE
Refactor user select constants

### DIFF
--- a/src/constants/prismaSelect.ts
+++ b/src/constants/prismaSelect.ts
@@ -1,0 +1,11 @@
+export const USER_SELECT = {
+  id: true,
+  name: true,
+  email: true,
+  avatar: true,
+  whatsapp: true,
+  instagram: true,
+  contactPreference: true,
+  createdAt: true,
+  updatedAt: true
+} as const;

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { USER_SELECT } from '../constants/prismaSelect';
 import { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import * as jwt from 'jsonwebtoken';
@@ -31,17 +32,7 @@ export const authMiddleware = (
     
     prisma.user.findUnique({
       where: { id: data.id },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        avatar: true,
-        whatsapp: true,
-        instagram: true,
-        contactPreference: true,
-        createdAt: true,
-        updatedAt: true
-      }
+      select: USER_SELECT
     }).then(user => {
       if (!user) {
         res.status(StatusCodes.UNAUTHORIZED).json({ error: 'Usuário não encontrado' });

--- a/src/repositories/PetRepository.ts
+++ b/src/repositories/PetRepository.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from '@prisma/client';
+import { USER_SELECT } from '../constants/prismaSelect';
 import { PetCreate, PetResponse } from '../types';
 import { IRepository } from './interfaces/IRepository';
 
@@ -13,17 +14,7 @@ export class PetRepository implements IRepository<PetResponse> {
     const pets = await this.prisma.pet.findMany({
       include: {
         user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true,
-            createdAt: true,
-            updatedAt: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -35,17 +26,7 @@ export class PetRepository implements IRepository<PetResponse> {
       where: { id },
       include: {
         user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true,
-            createdAt: true,
-            updatedAt: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -57,17 +38,7 @@ export class PetRepository implements IRepository<PetResponse> {
       data,
       include: {
         user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true,
-            createdAt: true,
-            updatedAt: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -80,17 +51,7 @@ export class PetRepository implements IRepository<PetResponse> {
       data,
       include: {
         user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true,
-            createdAt: true,
-            updatedAt: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -108,17 +69,7 @@ export class PetRepository implements IRepository<PetResponse> {
       where: { userId },
       include: {
         user: {
-          select: {
-            id: true,
-            name: true,
-            email: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true,
-            createdAt: true,
-            updatedAt: true
-          }
+          select: USER_SELECT
         },
         posts: {
           orderBy: {

--- a/src/repositories/PostRepository.ts
+++ b/src/repositories/PostRepository.ts
@@ -1,4 +1,5 @@
 import { Post, PrismaClient } from '@prisma/client';
+import { USER_SELECT } from '../constants/prismaSelect';
 import { CreatePostDTO, PostFilters, UpdatePostDTO } from '../types';
 import { IRepository } from './interfaces/IRepository';
 
@@ -14,14 +15,7 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -33,14 +27,7 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -52,14 +39,7 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -106,14 +86,7 @@ export class PostRepository implements IRepository<Post> {
         include: {
           pet: true,
           user: {
-            select: {
-              id: true,
-              name: true,
-              avatar: true,
-              whatsapp: true,
-              instagram: true,
-              contactPreference: true
-            }
+            select: USER_SELECT
           }
         }
       }),
@@ -136,14 +109,7 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       }
     });
@@ -161,14 +127,7 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       },
       orderBy: {
@@ -183,16 +142,9 @@ export class PostRepository implements IRepository<Post> {
       include: {
         pet: true,
         user: {
-          select: {
-            id: true,
-            name: true,
-            avatar: true,
-            whatsapp: true,
-            instagram: true,
-            contactPreference: true
-          }
+          select: USER_SELECT
         }
       }
     });
   }
-} 
+}


### PR DESCRIPTION
## Summary
- centralize the user selection fields in `USER_SELECT`
- refactor repositories and middleware to use this constant

## Testing
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab93aea0832d90d198f477e8a9b9