### PR TITLE
Remove redundant PrismaClient instances

### DIFF
--- a/src/repositories/NotificationTokenRepository.ts
+++ b/src/repositories/NotificationTokenRepository.ts
@@ -1,31 +1,31 @@
-import { PrismaClient, NotificationToken } from '@prisma/client';
+import { NotificationToken } from '@prisma/client';
+import { prisma } from '../config/prisma';
 
 export class NotificationTokenRepository {
-  private prisma: PrismaClient;
 
   constructor() {
-    this.prisma = new PrismaClient();
+    // Using the shared Prisma instance
   }
 
   async upsert(token: string, userId: string): Promise<NotificationToken> {
-    const existing = await this.prisma.notificationToken.findUnique({
+    const existing = await prisma.notificationToken.findUnique({
       where: { token }
     });
 
     if (existing) {
-      return this.prisma.notificationToken.update({
+      return prisma.notificationToken.update({
         where: { token },
         data: { userId }
       });
     }
 
-    return this.prisma.notificationToken.create({
+    return prisma.notificationToken.create({
       data: { token, userId }
     });
   }
 
   async findByUserIds(userIds: string[]): Promise<NotificationToken[]> {
-    return this.prisma.notificationToken.findMany({
+    return prisma.notificationToken.findMany({
       where: { userId: { in: userIds } }
     });
   }

--- a/src/services/NotificationService.ts
+++ b/src/services/NotificationService.ts
@@ -1,13 +1,11 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '../config/prisma';
 import fetch from 'node-fetch';
 import { NotificationTokenRepository } from '../repositories/NotificationTokenRepository';
 
 export class NotificationService {
-  private prisma: PrismaClient;
   private tokenRepo: NotificationTokenRepository;
 
   constructor() {
-    this.prisma = new PrismaClient();
     this.tokenRepo = new NotificationTokenRepository();
   }
 
@@ -30,7 +28,7 @@ export class NotificationService {
   }
 
   async notifyNearbyUsers(postId: string) {
-    const post = await this.prisma.post.findUnique({
+    const post = await prisma.post.findUnique({
       where: { id: postId },
       include: {
         user: true
@@ -41,7 +39,7 @@ export class NotificationService {
       return;
     }
 
-    const users = await this.prisma.user.findMany({
+    const users = await prisma.user.findMany({
       where: {
         id: { not: post.userId },
         latitude: { not: null },

--- a/src/services/PostService.ts
+++ b/src/services/PostService.ts
@@ -1,4 +1,5 @@
-import { Post, PrismaClient } from '@prisma/client';
+import { Post } from '@prisma/client';
+import { prisma } from '../config/prisma';
 import { StatusCodes } from 'http-status-codes';
 import { AppError } from '../errors/AppError';
 import { PostRepository } from '../repositories/PostRepository';
@@ -7,12 +8,10 @@ import { NotificationService } from './NotificationService';
 
 export class PostService {
   private repository: PostRepository;
-  private prisma: PrismaClient;
   private notificationService: NotificationService;
 
   constructor() {
     this.repository = new PostRepository();
-    this.prisma = new PrismaClient();
     this.notificationService = new NotificationService();
   }
 
@@ -64,7 +63,7 @@ export class PostService {
 
   async findByUserId(userId: string): Promise<Post[]> {
     // Verifica se o usuário existe
-    const user = await this.prisma.user.findUnique({
+    const user = await prisma.user.findUnique({
       where: { id: userId }
     });
 


### PR DESCRIPTION
## Summary
- use the shared Prisma client in PostService, NotificationService and NotificationTokenRepository
- drop unused PrismaClient imports

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_684075485e54832d86c980bc92c6ed0b